### PR TITLE
Add `--split-wheels` option to pip-compile to split non-wheel packages out into a separate requirements file

### DIFF
--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -21,13 +21,18 @@ from ..locations import CACHE_DIR
 from ..logging import log
 from ..repositories import LocalRequirementsRepository, PyPIRepository
 from ..resolver import Resolver
-from ..utils import (UNSAFE_PACKAGES, dedup, format_suffixed_path,
-                     is_pinned_requirement, key_from_ireq)
+from ..utils import (
+    UNSAFE_PACKAGES,
+    dedup,
+    format_suffixed_path,
+    is_pinned_requirement,
+    key_from_ireq,
+)
 from ..writer import OutputWriter
 
 DEFAULT_REQUIREMENTS_FILE = "requirements.in"
 DEFAULT_REQUIREMENTS_OUTPUT_FILE = "requirements.txt"
-WHEELS_REQUIREMENTS_SUFFIX = '_wheels'
+WHEELS_REQUIREMENTS_SUFFIX = "_wheels"
 
 
 def _get_default_option(option_name):
@@ -483,8 +488,9 @@ def cli(
         find_links=repository.finder.find_links,
         emit_find_links=emit_find_links,
     )
-    markers = {key_from_ireq(ireq): ireq.markers for ireq in constraints
-               if ireq.markers}
+    markers = {
+        key_from_ireq(ireq): ireq.markers for ireq in constraints if ireq.markers
+    }
 
     def write(results, output_file):
         if generate_hashes:
@@ -508,7 +514,10 @@ def cli(
         results -= results_wheels
         wheels_output = click.open_file(
             format_suffixed_path(output_file.name, WHEELS_REQUIREMENTS_SUFFIX),
-            "w+b", atomic=True, lazy=True)
+            "w+b",
+            atomic=True,
+            lazy=True,
+        )
         ctx.call_on_close(safecall(wheels_output.close_intelligently))
         write(results_wheels, wheels_output)
 

--- a/piptools/scripts/sync.py
+++ b/piptools/scripts/sync.py
@@ -14,9 +14,10 @@ from .._compat import parse_requirements
 from ..exceptions import PipToolsError
 from ..logging import log
 from ..repositories import PyPIRepository
-from ..utils import flat_map
+from ..utils import flat_map, format_suffixed_path
 
 DEFAULT_REQUIREMENTS_FILE = "requirements.txt"
+WHEELS_REQUIREMENTS_SUFFIX = '_wheels'
 
 
 @click.command(context_settings={"help_option_names": ("-h", "--help")})
@@ -106,6 +107,16 @@ def cli(
         else:
             log.error("ERROR: " + msg)
             sys.exit(2)
+
+    # include the wheels requirements txt if we find any files with `_wheels`
+    # suffix
+    wheel_req_files = set()
+    for src_file in src_files:
+        wheel_src = format_suffixed_path(src_file, WHEELS_REQUIREMENTS_SUFFIX)
+        if os.path.exists(wheel_src):
+            wheel_req_files.add(wheel_src)
+    src_files = list(src_files)
+    src_files.extend(list(wheel_req_files))
 
     install_command = create_command("install")
     options, _ = install_command.parse_args([])

--- a/piptools/scripts/sync.py
+++ b/piptools/scripts/sync.py
@@ -17,7 +17,7 @@ from ..repositories import PyPIRepository
 from ..utils import flat_map, format_suffixed_path
 
 DEFAULT_REQUIREMENTS_FILE = "requirements.txt"
-WHEELS_REQUIREMENTS_SUFFIX = '_wheels'
+WHEELS_REQUIREMENTS_SUFFIX = "_wheels"
 
 
 @click.command(context_settings={"help_option_names": ("-h", "--help")})

--- a/piptools/utils.py
+++ b/piptools/utils.py
@@ -382,3 +382,17 @@ def get_compile_command(click_ctx):
                     )
 
     return " ".join(["pip-compile"] + sorted(left_args) + sorted(right_args))
+
+
+def format_suffixed_path(src_file, suffix):
+    """
+    Return a suffixed file path based on the source file path passed in.
+
+    :type src_file: str
+    :type suffix: str
+    :rtype: str
+    """
+    import os
+
+    name, ext = os.path.splitext(src_file)
+    return name + suffix + ext

--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -80,6 +80,12 @@ def test_command_line_setuptools_read(pip_conf, runner):
         # For the `pip-compile --output-file=output.txt`
         # output file should be "output.txt"
         (["--output-file", "output.txt"], "output.txt"),
+        # For the `pip-compile --split-wheels`
+        # output file should be "requirements.txt" nad "requirements_wheels.txt"
+        (["--split-wheels"], ["requirements.txt", "requirements_wheels.txt"]),
+        # For the `pip-compile --output-file=output.txt --split-wheels`
+        # output file should be "output.txt" and "output_wheels.txt"
+        (["--output-file", "output.txt", "--split-wheels"], ["output.txt", "output_wheels.txt"]),
         # For the `pip-compile setup.py` output file should be "requirements.txt"
         (["setup.py"], "requirements.txt"),
         # For the `pip-compile setup.py --output-file=output.txt`
@@ -105,7 +111,10 @@ def test_command_line_setuptools_output_file(
 
     out = runner.invoke(cli, options)
     assert out.exit_code == 0
-    assert os.path.exists(expected_output_file)
+    if not isinstance(expected_output_file, list):
+        expected_output_file = [expected_output_file]
+    for f in expected_output_file:
+        assert os.path.exists(f)
 
 
 def test_find_links_option(runner):

--- a/tests/test_cli_compile.py
+++ b/tests/test_cli_compile.py
@@ -85,7 +85,10 @@ def test_command_line_setuptools_read(pip_conf, runner):
         (["--split-wheels"], ["requirements.txt", "requirements_wheels.txt"]),
         # For the `pip-compile --output-file=output.txt --split-wheels`
         # output file should be "output.txt" and "output_wheels.txt"
-        (["--output-file", "output.txt", "--split-wheels"], ["output.txt", "output_wheels.txt"]),
+        (
+            ["--output-file", "output.txt", "--split-wheels"],
+            ["output.txt", "output_wheels.txt"],
+        ),
         # For the `pip-compile setup.py` output file should be "requirements.txt"
         (["setup.py"], "requirements.txt"),
         # For the `pip-compile setup.py --output-file=output.txt`


### PR DESCRIPTION
<!--- Describe the changes here. --->

**Changelog-friendly one-liner**: <!-- One-liner description here -->

##### Contributor checklist

- [ ] Provided the tests for the changes.
- [ ] Gave a clear one-line description in the PR (that the maintainers can add to CHANGELOG.md on release).
- [ ] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
